### PR TITLE
Fix compatibility issues with 2021.06 Naver portal

### DIFF
--- a/navernewscrawler/naver_crawler.py
+++ b/navernewscrawler/naver_crawler.py
@@ -20,7 +20,8 @@ def get_news(n_url):
     list
     """
     news_detail = []
-    breq = requests.get(n_url)
+    headers = {'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36'}
+    breq = requests.get(n_url, headers=headers)
     bsoup = BeautifulSoup(breq.content, 'html.parser')
     title = bsoup.select('h3#articleTitle')[0].text
     news_detail.append(title)
@@ -97,10 +98,10 @@ def output(query,page,max_page,start_date,end_date):
             req = requests.get(url,headers=header)
             cont = req.content
             soup = BeautifulSoup(cont, 'html.parser')
-            for urls in soup.select("._sp_each_url"):
+            for url in soup.find_all('a', href=True):
                 try:
-                    if urls["href"].startswith("https://news.naver.com"):
-                        news_detail = get_news(urls["href"])
+                    if url['href'].startswith('https://news.naver.com'):
+                        news_detail = get_news(url["href"])
                         adict = dict()
                         adict["title"] = news_detail[0]
                         adict["date"] = news_detail[1]


### PR DESCRIPTION
Thanks for the useful package. I added small edits to `naver_crawler.py` to have it work with the latest Naver portal:

- `get_news()` - Include `headers` parameter into the `requests.get()` calls for each news articles. Uses the same `headers` already defined in `output()`. Otherwise throws `RemoteDisconnected` Error.
- `output()` - Scrape the list of news articles by looking for `<a>` tags, rather than `soup.select("._sp_each_url")`. Otherwise returns empty list.

Please review and let me know your thoughts! Thanks :) 감사합니다~